### PR TITLE
Declare setuptools as a runtime dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 [options]
 packages = outdated
 install_requires =
+    setuptools>=44
     littleutils
     requests
 


### PR DESCRIPTION
Fixes: https://github.com/alexmojaki/outdated/issues/12

`setuptools` is an undeclared runtime dependency currently, it is used here: https://github.com/alexmojaki/outdated/blob/591f80b0038b5d56c8a09d6bef3f132cd00ee731/outdated/__init__.py#L36

`pyproject.toml` declares it as a build dependency, but build dependencies do not need to be kept around during installation and afterwards in isolated build environments, which python stuff is moving towards. For many people this problem might not manifest if they have setuptools installed in their environment in the first place, but for people who don't it causes issues.

This PR declares `setuptools` as a runtime dependency.